### PR TITLE
API v2 "no fields shortcut"

### DIFF
--- a/accepted/005-wagtail-api-fields.rst
+++ b/accepted/005-wagtail-api-fields.rst
@@ -121,6 +121,19 @@ to be returned:
         "height": 100
     }
 
+No fields shortcut
+------------------
+
+Like the "all fields shortcut" the ``_`` character can be used to remove all fields.
+This would typically be used by developers who know they only need specific fields:
+
+.. code-block::
+
+    /?fields=_,title
+
+    {
+        "title": "Wagtail by Mark Harkin"
+    }
 
 Nested objects
 --------------


### PR DESCRIPTION
Addition to #5

Similar to the way the * shortcut adds all fields to the response. This commit adds the _ shortcut, which removes all fields from the response.

Developers who know the fields they need could use this to remove the overhead of having to send all the default field data.